### PR TITLE
fix: increase maxDuration to 60s for score-words API route

### DIFF
--- a/src/app/api/admin/saltong/score-words/route.ts
+++ b/src/app/api/admin/saltong/score-words/route.ts
@@ -3,6 +3,8 @@ import OpenAI from "openai";
 import { z } from "zod";
 import { zodTextFormat } from "openai/helpers/zod";
 
+export const maxDuration = 60;
+
 const openai = new OpenAI({
   apiKey: process.env.OPENAI_API_KEY,
 });


### PR DESCRIPTION
The `/api/admin/saltong/score-words` route was hitting Vercel's default 10s function timeout when scoring 30 words via OpenAI, returning a 504 Gateway Timeout error.\n\nAdding `export const maxDuration = 60` increases the allowed execution time to 60 seconds.