### PR TITLE
[codex] Prompt incomplete profiles once per session

### DIFF
--- a/src/components/shared/app-sidebar/nav-user/index.tsx
+++ b/src/components/shared/app-sidebar/nav-user/index.tsx
@@ -8,6 +8,7 @@ import {
 } from "@/components/ui/sidebar";
 import { NavUserDropdown, UserDetail } from "../../nav-user-dropdown";
 import { ChevronsUpDown } from "lucide-react";
+import CompleteProfileSessionPrompt from "@/features/profiles/components/complete-profile-session-prompt";
 
 export default async function NavUser() {
   const supabase = await createClient();
@@ -37,22 +38,33 @@ export default async function NavUser() {
   const { profile, isTemporaryProfile, avatarOptions } = profileFormData ?? {};
 
   return (
-    <SidebarMenu>
-      <SidebarMenuItem>
-        <NavUserDropdown
-          profile={profile}
-          isTemporaryProfile={isTemporaryProfile}
+    <>
+      {isTemporaryProfile && (
+        <CompleteProfileSessionPrompt
+          userId={profile.id}
+          username={profile.username}
+          avatarUrl={profile.avatar_url ?? ""}
+          displayName={profile.display_name ?? ""}
           avatarOptions={avatarOptions}
-        >
-          <SidebarMenuButton
-            size="lg"
-            className="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
+        />
+      )}
+      <SidebarMenu>
+        <SidebarMenuItem>
+          <NavUserDropdown
+            profile={profile}
+            isTemporaryProfile={isTemporaryProfile}
+            avatarOptions={avatarOptions}
           >
-            <UserDetail {...profile} />
-            <ChevronsUpDown className="ml-auto size-4" />
-          </SidebarMenuButton>
-        </NavUserDropdown>
-      </SidebarMenuItem>
-    </SidebarMenu>
+            <SidebarMenuButton
+              size="lg"
+              className="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
+            >
+              <UserDetail {...profile} />
+              <ChevronsUpDown className="ml-auto size-4" />
+            </SidebarMenuButton>
+          </NavUserDropdown>
+        </SidebarMenuItem>
+      </SidebarMenu>
+    </>
   );
 }

--- a/src/features/profiles/components/complete-profile-session-prompt.tsx
+++ b/src/features/profiles/components/complete-profile-session-prompt.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import CompleteProfileDialog from "./complete-profile";
+
+const COMPLETE_PROFILE_PROMPT_SESSION_KEY = "complete-profile-prompt-shown";
+
+export default function CompleteProfileSessionPrompt({
+  userId,
+  username,
+  avatarUrl,
+  displayName,
+  avatarOptions,
+}: {
+  userId: string;
+  username?: string;
+  avatarUrl?: string;
+  displayName?: string;
+  avatarOptions?: { value: string; label?: string }[];
+}) {
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    if (sessionStorage.getItem(COMPLETE_PROFILE_PROMPT_SESSION_KEY)) {
+      return;
+    }
+
+    sessionStorage.setItem(COMPLETE_PROFILE_PROMPT_SESSION_KEY, "true");
+    const timeoutId = window.setTimeout(() => setOpen(true), 0);
+
+    return () => window.clearTimeout(timeoutId);
+  }, []);
+
+  return (
+    <CompleteProfileDialog
+      open={open}
+      onOpenChange={setOpen}
+      userId={userId}
+      username={username}
+      avatarUrl={avatarUrl}
+      displayName={displayName}
+      avatarOptions={avatarOptions}
+      action="close"
+    />
+  );
+}

--- a/src/features/profiles/components/complete-profile.tsx
+++ b/src/features/profiles/components/complete-profile.tsx
@@ -12,6 +12,7 @@ import { ReactNode } from "react";
 import ProfileEditorForm from "./profile-editor-form";
 import { useInsertProfileMutation } from "../hooks/profile";
 import { toast } from "sonner";
+import { useRouter } from "next/navigation";
 
 export default function CompleteProfileDialog({
   children,
@@ -35,6 +36,7 @@ export default function CompleteProfileDialog({
   action?: "redirect" | "close";
 }) {
   const { mutateAsync, isPending } = useInsertProfileMutation();
+  const router = useRouter();
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -62,12 +64,14 @@ export default function CompleteProfileDialog({
                 window.location.href = `/u/${data.username}`;
               } else if (onOpenChange) {
                 onOpenChange(false);
+                router.refresh();
               } else {
                 // Close the dialog by simulating a click on the overlay
                 const overlay = document.querySelector(
                   '[data-slot="dialog-overlay"]'
                 ) as HTMLElement;
                 overlay?.click();
+                router.refresh();
               }
             } catch (error) {
               let errorMessage = "An unknown error occurred";

--- a/src/features/profiles/components/complete-profile.tsx
+++ b/src/features/profiles/components/complete-profile.tsx
@@ -15,6 +15,8 @@ import { toast } from "sonner";
 
 export default function CompleteProfileDialog({
   children,
+  open,
+  onOpenChange,
   username,
   avatarUrl,
   displayName,
@@ -22,7 +24,9 @@ export default function CompleteProfileDialog({
   userId,
   action = "close",
 }: {
-  children: ReactNode;
+  children?: ReactNode;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
   username?: string;
   avatarUrl?: string;
   displayName?: string;
@@ -33,8 +37,8 @@ export default function CompleteProfileDialog({
   const { mutateAsync, isPending } = useInsertProfileMutation();
 
   return (
-    <Dialog>
-      <DialogTrigger asChild>{children}</DialogTrigger>
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      {children && <DialogTrigger asChild>{children}</DialogTrigger>}
       <DialogContent>
         <DialogHeader className="mb-3 gap-0">
           <DialogTitle className="mb-2 border-0 font-bold">
@@ -56,6 +60,8 @@ export default function CompleteProfileDialog({
 
               if (action === "redirect") {
                 window.location.href = `/u/${data.username}`;
+              } else if (onOpenChange) {
+                onOpenChange(false);
               } else {
                 // Close the dialog by simulating a click on the overlay
                 const overlay = document.querySelector(


### PR DESCRIPTION
## Summary
- add a per-session prompt for authenticated users with incomplete profiles
- make `CompleteProfileDialog` support controlled open state while preserving trigger usage
- render the prompt from the sidebar user area so it applies broadly without page-level wiring

## Validation
- pnpm exec tsc --noEmit
- pnpm lint (passes with existing turn-card unused-variable warning)