### PR TITLE
[codex] Improve win streak card layout

### DIFF
--- a/src/features/saltong/components/results/streak-card.tsx
+++ b/src/features/saltong/components/results/streak-card.tsx
@@ -21,6 +21,8 @@ export default function StreakCard({
 }) {
   const { currentWinStreak, longestWinStreak, totalLosses, totalWins } =
     userStats;
+  const streakValue = Number(currentWinStreak ?? 0);
+  const streakDigits = String(Math.abs(streakValue)).length;
   const totalGames = Math.max(Number(totalWins) + Number(totalLosses), 0);
   const winRate =
     totalGames > 0 ? Math.round((Number(totalWins) / totalGames) * 100) : 0;
@@ -47,68 +49,77 @@ export default function StreakCard({
         </CardAction>
       </CardHeader>
       <CardContent>
-        <div className="grid grid-cols-3 grid-rows-2">
-          <div className="relative row-span-2 flex w-full items-center justify-center select-none">
+        <div className="flex flex-col gap-6">
+          <div className="relative flex w-full items-center justify-center select-none">
             <div
               className={cn(
-                "absolute top-16 z-1 flex w-full items-center justify-center text-6xl font-bold tracking-tighter text-orange-100",
+                "absolute top-16 z-1 flex max-w-[7.5rem] items-center justify-center px-2 text-center font-bold tracking-tighter text-orange-100",
                 {
-                  "top-19 text-5xl tracking-tight":
-                    Number(currentWinStreak) >= 1000,
-                  "text-primary": !currentWinStreak,
+                  "top-[4.25rem] tracking-tight": streakDigits >= 4,
+                  "text-primary": !streakValue,
                 }
               )}
               style={{
-                WebkitTextStroke: !currentWinStreak
-                  ? "10px var(--color-muted)"
-                  : "10px var(--color-orange-500)",
+                fontSize: `clamp(1.5rem, calc(7rem / ${Math.max(
+                  streakDigits * 0.62,
+                  1
+                )}), 3.75rem)`,
+                WebkitTextStroke: !streakValue
+                  ? "0.12em var(--color-muted)"
+                  : "0.12em var(--color-orange-500)",
                 paintOrder: "stroke fill",
               }}
             >
-              {currentWinStreak ?? 0}
+              {streakValue}
             </div>
             <div className="flex w-full flex-col items-center justify-center gap-1">
               <FlameIcon
                 strokeWidth={2}
                 className={cn("size-30 text-orange-500", {
-                  "text-primary/20": !currentWinStreak,
+                  "text-primary/20": !streakValue,
                 })}
                 fill={
-                  !currentWinStreak
+                  !streakValue
                     ? "var(--color-muted)"
                     : "var(--color-orange-400)"
                 }
               />
               <span
                 className={cn("text-lg font-black text-orange-500", {
-                  "text-primary": !currentWinStreak,
+                  "text-primary": !streakValue,
                 })}
               >
-                DAY{Number(currentWinStreak) === 1 ? "" : "S"}
+                DAY{streakValue === 1 ? "" : "S"}
               </span>
             </div>
           </div>
-          <div className="flex flex-col items-center justify-center">
-            <div className="text-xl font-bold tracking-tighter">
-              {longestWinStreak}
+          <div className="grid grid-cols-2 gap-x-4 gap-y-6">
+            <div className="flex min-w-0 flex-col items-center justify-center text-center">
+              <div className="text-xl font-bold tracking-tighter">
+                {longestWinStreak}
+              </div>
+              <div className="text-muted-foreground text-sm">
+                Longest Streak
+              </div>
             </div>
-            <div className="text-muted-foreground text-sm">Longest Streak</div>
-          </div>
-          <div className="flex flex-col items-center justify-center">
-            <div className="text-xl font-bold tracking-tighter">{winRate}%</div>
-            <div className="text-muted-foreground text-sm">Win Rate</div>
-          </div>
-          <div className="flex flex-col items-center justify-center">
-            <div className="text-xl font-bold tracking-tighter">
-              {totalWins}
+            <div className="flex min-w-0 flex-col items-center justify-center text-center">
+              <div className="text-xl font-bold tracking-tighter">
+                {winRate}%
+              </div>
+              <div className="text-muted-foreground text-sm">Win Rate</div>
             </div>
-            <div className="text-muted-foreground text-sm">Total Wins</div>
-          </div>
-          <div className="flex flex-col items-center justify-center">
-            <div className="text-xl font-bold tracking-tighter">
-              {totalLosses}
+            <div className="flex min-w-0 flex-col items-center justify-center text-center">
+              <div className="text-xl font-bold tracking-tighter">
+                {totalWins}
+              </div>
+              <div className="text-muted-foreground text-sm">Total Wins</div>
             </div>
-            <div className="text-muted-foreground text-sm">Total Losses</div>
+            <div className="flex min-w-0 flex-col items-center justify-center text-center">
+              <div className="text-xl font-bold tracking-tighter">
+                {totalLosses}
+              </div>
+              <div className="text-muted-foreground text-sm">Total Losses</div>
+            </div>
           </div>
         </div>
       </CardContent>


### PR DESCRIPTION
## Summary

Improves the results dialog win streak card so it behaves better on narrow screens.

- Moves the flame/current streak display to a centered top area.
- Places the supporting stats in a stable 2x2 grid below it.
- Scales the streak number based on digit count so long streak values stay inside the flame.
- Center-aligns the stat labels, including Longest Streak and Total Losses.

## Validation

- `pnpm lint` passes with one existing warning in `src/features/saltong/components/results/turn-card.tsx` for an unused `avgTurnsDisplay` variable.
- `pnpm build` compiled successfully, then failed during page-data collection because `OPENAI_API_KEY` is not configured for `/api/admin/saltong/score-words`.

## Notes

Local runtime also requires Supabase env vars (`NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY`) to render the app without the existing Supabase client error.