### PR TITLE
[codex] Fix Saltong anonymous daily records

### DIFF
--- a/src/features/saltong/hooks/user-round.ts
+++ b/src/features/saltong/hooks/user-round.ts
@@ -41,7 +41,9 @@ export function useSaltongUserRound(params: SaltongUserRoundPrimaryKeys) {
         const data =
           localPlayerRound?.find(
             (round) =>
-              round.mode === params.mode && round.userId === params.userId
+              round.mode === params.mode &&
+              round.userId === params.userId &&
+              round.date === params.date
           ) ?? null;
         return data;
       }
@@ -74,7 +76,9 @@ export function useSaltongUserRoundMutation() {
         setLocalPlayerRound((prev) => {
           const existingIndex = prev.findIndex(
             (round) =>
-              round.mode === params.mode && round.userId === params.userId
+              round.mode === params.mode &&
+              round.userId === params.userId &&
+              round.date === params.date
           );
 
           const datedParams = {

--- a/src/features/saltong/hooks/vault-rounds.ts
+++ b/src/features/saltong/hooks/vault-rounds.ts
@@ -1,69 +1,19 @@
-import { useEffect } from "react";
-import { useLocalStorage } from "usehooks-ts";
 import { useSupabaseClient } from "@/lib/supabase/client";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
-import {
-  SaltongUserRound,
-  SaltongVaultRound,
-  SaltongVaultRoundsParams,
-} from "../types";
+import { useQuery } from "@tanstack/react-query";
+import { SaltongVaultRound, SaltongVaultRoundsParams } from "../types";
 import { getSaltongVaultRounds } from "../queries/getSaltongVaultRounds";
 
 /**
  * Fetches user rounds in a date range for a given user and mode.
  * Returns only { date, isCorrect, endedAt } for each round.
- * Handles unauthenticated users via localStorage.
  */
 export function useSaltongVaultRounds(params: SaltongVaultRoundsParams) {
   const { userId, mode, startDate, endDate } = params;
-  const [localPlayerRounds] = useLocalStorage<SaltongUserRound[]>(
-    "saltong-vault-rounds",
-    [],
-    { initializeWithValue: false }
-  );
   const supabase = useSupabaseClient();
-  const queryClient = useQueryClient();
-
-  // Keep cache in sync for unauthenticated users
-  useEffect(() => {
-    if (userId === "unauthenticated") {
-      const filtered = localPlayerRounds.filter(
-        (round) =>
-          round.mode === mode &&
-          round.userId === userId &&
-          round.date >= startDate &&
-          round.date <= endDate
-      );
-      queryClient.setQueryData(
-        ["saltong-vault-round", { userId, mode, startDate, endDate }],
-        filtered
-      );
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [localPlayerRounds, userId, mode, startDate, endDate]);
 
   return useQuery({
     queryKey: ["saltong-vault-rounds", { userId, mode, startDate, endDate }],
     queryFn: async () => {
-      if (userId === "unauthenticated") {
-        return localPlayerRounds
-          .filter(
-            (round) =>
-              round.mode === mode &&
-              round.userId === userId &&
-              round.date >= startDate &&
-              round.date <= endDate
-          )
-          .map(
-            ({ date, isCorrect, endedAt }) =>
-              ({
-                date,
-                isCorrect,
-                endedAt,
-              }) satisfies SaltongVaultRound
-          );
-      }
-
       const { data, error } = await getSaltongVaultRounds(supabase, {
         userId,
         mode,


### PR DESCRIPTION
## Summary

Fixes Saltong anonymous round persistence so local gameplay records are stored per day instead of one row per mode.

## What changed

- Include `date` when reading anonymous Saltong user rounds from localStorage.
- Include `date` when updating anonymous Saltong user rounds, preventing one day from overwriting another.
- Remove the unused anonymous/localStorage path from the Saltong vault hook, since the vault page is authenticated-only and reads from Supabase.

## Impact

Unauthenticated Saltong players now keep distinct local records for different daily rounds. Authenticated vault behavior remains Supabase-backed and unchanged.

## Validation

- `pnpm lint` passes with 0 errors.
- Existing warning remains: unused `avgTurnsDisplay` in `src/features/saltong/components/results/turn-card.tsx`.
