### PR TITLE
Add Filipino word game landing page

### DIFF
--- a/src/app/filipino-wordle/copy.ts
+++ b/src/app/filipino-wordle/copy.ts
@@ -2,13 +2,40 @@ export const FILIPINO_WORDLE_LANDING_COPY = {
   title: "Saltong: A Daily Filipino Word Game",
   description:
     "Play Saltong, a daily Filipino word game built around Filipino language and words.",
-  eyebrow: "A Daily Filipino Word Game",
-  hero: "Meet Saltong",
-  introduction:
-    "A small daily ritual for Filipino word lovers—one puzzle, a fresh word, and a reason to return tomorrow.",
-  story:
-    "I created Saltong during COVID while I was stuck in my room and missing the small ways we used to share a challenge with friends. Inspired by Wordle, I wanted to make that feeling feel Filipino: a daily word game built around the language we use and love. What began as a personal project has grown into a community of more than 650,000 players and over 12 million pageviews.",
+  hero: "Play Saltong",
+  introduction: "A daily Filipino word game with four ways to play.",
+  searchCopy:
+    "Looking for a Filipino Wordle, Tagalog Wordle, or Filipino Spelling Bee? Saltong Hub is a collection of independent daily Filipino word games with a fresh puzzle to solve every day.",
+  history:
+    "Saltong Hub is home to a collection of daily Filipino word games. I created Saltong during COVID while I was stuck in my room. Inspired by Wordle, I wanted to make that shared daily ritual feel Filipino. Saltong Hex later added a Filipino word-finding challenge inspired by the Spelling Bee format. What began as a tiny personal project has grown into a community of more than 650,000 players and over 12 million pageviews.",
   independenceNotice:
-    "Saltong is independently created and is not affiliated with or endorsed by Wordle or The New York Times.",
+    "Saltong Hub is independently created and is not affiliated with or endorsed by Wordle, Spelling Bee, or The New York Times.",
   playLabel: "Play Saltong",
 } as const;
+
+export const LANDING_GAMES = [
+  {
+    name: "Saltong",
+    href: "/play",
+    icon: "/main.svg",
+    color: "green",
+  },
+  {
+    name: "Saltong Mini",
+    href: "/play/mini",
+    icon: "/mini.svg",
+    color: "blue",
+  },
+  {
+    name: "Saltong Max",
+    href: "/play/max",
+    icon: "/max.svg",
+    color: "red",
+  },
+  {
+    name: "Saltong Hex",
+    href: "/play/hex",
+    icon: "/hex.svg",
+    color: "purple",
+  },
+] as const;

--- a/src/app/filipino-wordle/copy.ts
+++ b/src/app/filipino-wordle/copy.ts
@@ -1,0 +1,14 @@
+export const FILIPINO_WORDLE_LANDING_COPY = {
+  title: "Saltong: A Daily Filipino Word Game",
+  description:
+    "Play Saltong, a daily Filipino word game built around Filipino language and words.",
+  eyebrow: "A Daily Filipino Word Game",
+  hero: "Meet Saltong",
+  introduction:
+    "A small daily ritual for Filipino word lovers—one puzzle, a fresh word, and a reason to return tomorrow.",
+  story:
+    "I created Saltong during COVID while I was stuck in my room and missing the small ways we used to share a challenge with friends. Inspired by Wordle, I wanted to make that feeling feel Filipino: a daily word game built around the language we use and love. What began as a personal project has grown into a community of more than 650,000 players and over 12 million pageviews.",
+  independenceNotice:
+    "Saltong is independently created and is not affiliated with or endorsed by Wordle or The New York Times.",
+  playLabel: "Play Saltong",
+} as const;

--- a/src/app/filipino-wordle/landing-story.test.ts
+++ b/src/app/filipino-wordle/landing-story.test.ts
@@ -1,0 +1,17 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { LandingStory } from "./landing-story";
+
+describe("LandingStory", () => {
+  it("presents Saltong Hub's independent game origins", () => {
+    const story = renderToStaticMarkup(createElement(LandingStory));
+
+    expect(story).toContain("Saltong Hub");
+    expect(story).toContain("How Saltong began");
+    expect(story).toContain("Inspired by Wordle");
+    expect(story).toContain("Spelling Bee");
+    expect(story).toContain("650,000 players");
+    expect(story).toContain("12 million pageviews");
+  });
+});

--- a/src/app/filipino-wordle/landing-story.tsx
+++ b/src/app/filipino-wordle/landing-story.tsx
@@ -1,0 +1,12 @@
+import { FILIPINO_WORDLE_LANDING_COPY } from "./copy";
+
+export function LandingStory() {
+  return (
+    <div className="mt-8 border-t pt-6">
+      <h2 className="text-lg font-bold">How Saltong began</h2>
+      <p className="text-muted-foreground mt-2">
+        {FILIPINO_WORDLE_LANDING_COPY.history}
+      </p>
+    </div>
+  );
+}

--- a/src/app/filipino-wordle/page.test.ts
+++ b/src/app/filipino-wordle/page.test.ts
@@ -3,9 +3,9 @@ import { metadata } from "./page";
 import { FILIPINO_WORDLE_LANDING_COPY } from "./copy";
 
 describe("Filipino word-game landing page", () => {
-  it("publishes indexable, canonical Saltong metadata without competitor terms in its description", () => {
+  it("publishes an absolute, indexable canonical title without competitor terms in its description", () => {
     expect(metadata).toMatchObject({
-      title: "Saltong: A Daily Filipino Word Game",
+      title: { absolute: "Saltong: A Daily Filipino Word Game" },
       description:
         "Play Saltong, a daily Filipino word game built around Filipino language and words.",
       alternates: {

--- a/src/app/filipino-wordle/page.test.ts
+++ b/src/app/filipino-wordle/page.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { metadata } from "./page";
+import { FILIPINO_WORDLE_LANDING_COPY } from "./copy";
+
+describe("Filipino word-game landing page", () => {
+  it("publishes indexable, canonical Saltong metadata without competitor terms in its description", () => {
+    expect(metadata).toMatchObject({
+      title: "Saltong: A Daily Filipino Word Game",
+      description:
+        "Play Saltong, a daily Filipino word game built around Filipino language and words.",
+      alternates: {
+        canonical: "https://www.saltong.com/filipino-wordle",
+      },
+      robots: { index: true, follow: true },
+      openGraph: {
+        url: "https://www.saltong.com/filipino-wordle",
+      },
+    });
+    expect(String(metadata.description)).not.toMatch(/wordle|spelling bee/i);
+  });
+
+  it("keeps the approved personal story and independence notice together", () => {
+    expect(FILIPINO_WORDLE_LANDING_COPY.story).toContain("Inspired by Wordle");
+    expect(FILIPINO_WORDLE_LANDING_COPY.story).toContain("650,000");
+    expect(FILIPINO_WORDLE_LANDING_COPY.story).toContain("12 million");
+    expect(FILIPINO_WORDLE_LANDING_COPY.independenceNotice).toBe(
+      "Saltong is independently created and is not affiliated with or endorsed by Wordle or The New York Times."
+    );
+  });
+});

--- a/src/app/filipino-wordle/page.test.ts
+++ b/src/app/filipino-wordle/page.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { metadata } from "./page";
-import { FILIPINO_WORDLE_LANDING_COPY } from "./copy";
+import { FILIPINO_WORDLE_LANDING_COPY, LANDING_GAMES } from "./copy";
 
 describe("Filipino word-game landing page", () => {
   it("publishes an absolute, indexable canonical title without competitor terms in its description", () => {
@@ -19,12 +19,42 @@ describe("Filipino word-game landing page", () => {
     expect(String(metadata.description)).not.toMatch(/wordle|spelling bee/i);
   });
 
-  it("keeps the approved personal story and independence notice together", () => {
-    expect(FILIPINO_WORDLE_LANDING_COPY.story).toContain("Inspired by Wordle");
-    expect(FILIPINO_WORDLE_LANDING_COPY.story).toContain("650,000");
-    expect(FILIPINO_WORDLE_LANDING_COPY.story).toContain("12 million");
-    expect(FILIPINO_WORDLE_LANDING_COPY.independenceNotice).toBe(
-      "Saltong is independently created and is not affiliated with or endorsed by Wordle or The New York Times."
+  it("uses the target search language with the independence notice", () => {
+    expect(FILIPINO_WORDLE_LANDING_COPY.searchCopy).toContain(
+      "Filipino Wordle"
     );
+    expect(FILIPINO_WORDLE_LANDING_COPY.searchCopy).toContain("Tagalog Wordle");
+    expect(FILIPINO_WORDLE_LANDING_COPY.independenceNotice).toBe(
+      "Saltong Hub is independently created and is not affiliated with or endorsed by Wordle, Spelling Bee, or The New York Times."
+    );
+  });
+
+  it("gives visitors an immediate direct path into every Saltong game", () => {
+    expect(LANDING_GAMES).toEqual([
+      {
+        name: "Saltong",
+        href: "/play",
+        icon: "/main.svg",
+        color: "green",
+      },
+      {
+        name: "Saltong Mini",
+        href: "/play/mini",
+        icon: "/mini.svg",
+        color: "blue",
+      },
+      {
+        name: "Saltong Max",
+        href: "/play/max",
+        icon: "/max.svg",
+        color: "red",
+      },
+      {
+        name: "Saltong Hex",
+        href: "/play/hex",
+        icon: "/hex.svg",
+        color: "purple",
+      },
+    ]);
   });
 });

--- a/src/app/filipino-wordle/page.tsx
+++ b/src/app/filipino-wordle/page.tsx
@@ -8,7 +8,7 @@ import { canonicalUrl, pageIndexingMetadata } from "@/lib/seo";
 import { FILIPINO_WORDLE_LANDING_COPY } from "./copy";
 
 export const metadata: Metadata = {
-  title: FILIPINO_WORDLE_LANDING_COPY.title,
+  title: { absolute: FILIPINO_WORDLE_LANDING_COPY.title },
   description: FILIPINO_WORDLE_LANDING_COPY.description,
   ...pageIndexingMetadata("/filipino-wordle", true),
   openGraph: {

--- a/src/app/filipino-wordle/page.tsx
+++ b/src/app/filipino-wordle/page.tsx
@@ -1,11 +1,22 @@
 import type { Metadata } from "next";
+import Image from "next/image";
 import Link from "next/link";
 import HomeNavbarBrand from "@/app/components/home-navbar-brand";
 import { Navbar } from "@/components/shared/navbar";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { canonicalUrl, pageIndexingMetadata } from "@/lib/seo";
-import { FILIPINO_WORDLE_LANDING_COPY } from "./copy";
+import { cn } from "@/lib/utils";
+import { FILIPINO_WORDLE_LANDING_COPY, LANDING_GAMES } from "./copy";
+import { LandingStory } from "./landing-story";
+
+const gameButtonStyles = {
+  green:
+    "border-saltong-green-300 hover:bg-saltong-green-50 dark:hover:bg-saltong-green-950/30",
+  blue: "border-saltong-blue-300 hover:bg-saltong-blue-50 dark:hover:bg-saltong-blue-950/30",
+  red: "border-saltong-red-300 hover:bg-saltong-red-50 dark:hover:bg-saltong-red-950/30",
+  purple:
+    "border-saltong-purple-300 hover:bg-saltong-purple-50 dark:hover:bg-saltong-purple-950/30",
+} as const;
 
 export const metadata: Metadata = {
   title: { absolute: FILIPINO_WORDLE_LANDING_COPY.title },
@@ -25,35 +36,46 @@ export default function FilipinoWordlePage() {
       <Navbar>
         <HomeNavbarBrand />
       </Navbar>
-      <main>
-        <section className="mx-auto flex w-full max-w-3xl flex-col gap-8 px-4 py-12 sm:py-20">
-          <div className="space-y-4 text-center">
-            <p className="text-muted-foreground text-sm font-medium tracking-wide uppercase">
-              {FILIPINO_WORDLE_LANDING_COPY.eyebrow}
-            </p>
-            <h1 className="text-4xl font-bold tracking-tight sm:text-5xl">
-              {FILIPINO_WORDLE_LANDING_COPY.hero}
-            </h1>
-            <p className="text-muted-foreground mx-auto max-w-2xl text-lg leading-relaxed">
-              {FILIPINO_WORDLE_LANDING_COPY.introduction}
-            </p>
-            <Button asChild size="lg">
-              <Link href="/play">{FILIPINO_WORDLE_LANDING_COPY.playLabel}</Link>
-            </Button>
+      <main className="mx-auto w-full max-w-3xl px-4 py-10 sm:px-6 sm:py-14">
+        <section className="text-center">
+          <h1 className="text-3xl font-bold tracking-tight sm:text-4xl">
+            {FILIPINO_WORDLE_LANDING_COPY.hero}
+          </h1>
+          <p className="text-muted-foreground mt-2 text-base">
+            {FILIPINO_WORDLE_LANDING_COPY.introduction}
+          </p>
+
+          <div className="mt-7 grid grid-cols-2 gap-3 sm:grid-cols-4">
+            {LANDING_GAMES.map((game) => (
+              <Button
+                key={game.href}
+                asChild
+                variant="outline"
+                className={cn(
+                  "bg-background h-20 flex-col gap-2 border text-sm font-bold shadow-none",
+                  gameButtonStyles[game.color]
+                )}
+              >
+                <Link href={game.href}>
+                  <Image src={game.icon} alt="" width={28} height={28} />
+                  {game.name}
+                </Link>
+              </Button>
+            ))}
           </div>
-          <Card>
-            <CardHeader>
-              <CardTitle>How Saltong began</CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              <p className="leading-relaxed">
-                {FILIPINO_WORDLE_LANDING_COPY.story}
-              </p>
-              <p className="text-muted-foreground text-sm leading-relaxed">
-                {FILIPINO_WORDLE_LANDING_COPY.independenceNotice}
-              </p>
-            </CardContent>
-          </Card>
+        </section>
+
+        <section className="mt-12 border-t pt-8 text-sm leading-relaxed">
+          <h2 className="text-lg font-bold">
+            A Filipino and Tagalog word game
+          </h2>
+          <p className="text-muted-foreground mt-2">
+            {FILIPINO_WORDLE_LANDING_COPY.searchCopy}
+          </p>
+          <LandingStory />
+          <p className="text-muted-foreground mt-3 text-xs">
+            {FILIPINO_WORDLE_LANDING_COPY.independenceNotice}
+          </p>
         </section>
       </main>
     </>

--- a/src/app/filipino-wordle/page.tsx
+++ b/src/app/filipino-wordle/page.tsx
@@ -1,0 +1,61 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import HomeNavbarBrand from "@/app/components/home-navbar-brand";
+import { Navbar } from "@/components/shared/navbar";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { canonicalUrl, pageIndexingMetadata } from "@/lib/seo";
+import { FILIPINO_WORDLE_LANDING_COPY } from "./copy";
+
+export const metadata: Metadata = {
+  title: FILIPINO_WORDLE_LANDING_COPY.title,
+  description: FILIPINO_WORDLE_LANDING_COPY.description,
+  ...pageIndexingMetadata("/filipino-wordle", true),
+  openGraph: {
+    title: FILIPINO_WORDLE_LANDING_COPY.title,
+    description: FILIPINO_WORDLE_LANDING_COPY.description,
+    type: "website",
+    url: canonicalUrl("/filipino-wordle"),
+  },
+};
+
+export default function FilipinoWordlePage() {
+  return (
+    <>
+      <Navbar>
+        <HomeNavbarBrand />
+      </Navbar>
+      <main>
+        <section className="mx-auto flex w-full max-w-3xl flex-col gap-8 px-4 py-12 sm:py-20">
+          <div className="space-y-4 text-center">
+            <p className="text-muted-foreground text-sm font-medium tracking-wide uppercase">
+              {FILIPINO_WORDLE_LANDING_COPY.eyebrow}
+            </p>
+            <h1 className="text-4xl font-bold tracking-tight sm:text-5xl">
+              {FILIPINO_WORDLE_LANDING_COPY.hero}
+            </h1>
+            <p className="text-muted-foreground mx-auto max-w-2xl text-lg leading-relaxed">
+              {FILIPINO_WORDLE_LANDING_COPY.introduction}
+            </p>
+            <Button asChild size="lg">
+              <Link href="/play">{FILIPINO_WORDLE_LANDING_COPY.playLabel}</Link>
+            </Button>
+          </div>
+          <Card>
+            <CardHeader>
+              <CardTitle>How Saltong began</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <p className="leading-relaxed">
+                {FILIPINO_WORDLE_LANDING_COPY.story}
+              </p>
+              <p className="text-muted-foreground text-sm leading-relaxed">
+                {FILIPINO_WORDLE_LANDING_COPY.independenceNotice}
+              </p>
+            </CardContent>
+          </Card>
+        </section>
+      </main>
+    </>
+  );
+}

--- a/src/app/sitemap.test.ts
+++ b/src/app/sitemap.test.ts
@@ -8,4 +8,14 @@ describe("sitemap", () => {
   it("does not submit login-gated vault routes", () => {
     expect(sitemap().some((entry) => entry.url.includes("/vault"))).toBe(false);
   });
+
+  it("submits the evergreen Filipino word-game landing page", () => {
+    expect(sitemap()).toContainEqual(
+      expect.objectContaining({
+        url: "https://www.saltong.com/filipino-wordle",
+        changeFrequency: "monthly",
+        priority: 0.8,
+      })
+    );
+  });
 });

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -43,6 +43,12 @@ export default function sitemap(): MetadataRoute.Sitemap {
       changeFrequency: "monthly" as const,
       priority: 0.8,
     },
+    {
+      url: `${baseUrl}/filipino-wordle`,
+      lastModified: new Date(),
+      changeFrequency: "monthly" as const,
+      priority: 0.8,
+    },
     // Other pages - Priority 0.3
     {
       url: `${baseUrl}/about`,


### PR DESCRIPTION
## What changed

- Adds the evergreen `/filipino-wordle` landing page for Saltong.
- Uses a personal origin story, a `/play` call to action, and a clear independent/non-affiliation notice.
- Publishes exact, canonical metadata without competitor terms in the meta description.
- Adds the page to the sitemap with monthly change frequency and `0.8` priority.

## Why

Saltong needs a focused, brand-led entry point for people searching for a Filipino word game, without changing game titles or associating the games themselves with third-party brands.

## Impact

Search engines can discover an indexable, canonical landing page that introduces Saltong and sends visitors directly to the daily game.

## Validation

- `pnpm test` — 7 files, 14 tests passed.
- `pnpm lint` — no errors; one pre-existing unused-variable warning remains.
- Independent task reviews and final review passed after correcting the inherited title-template interaction.
- Production build and live indexing remain to be verified after deployment because of the known local build-environment behavior.
