### PR TITLE
fix: consolidate apex canonical host signals

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -14,6 +14,7 @@ import ContributeDialog from "@/components/shared/contribute-dialog";
 import { Navbar } from "@/components/shared/navbar";
 import HomeNavbarBrand from "../components/home-navbar-brand";
 import { VERSION } from "@/version";
+import { canonicalUrl } from "@/lib/seo";
 
 export const metadata: Metadata = {
   title: "About Saltong Hub",
@@ -24,7 +25,7 @@ export const metadata: Metadata = {
     description:
       "Learn about Saltong Hub, the platform for Filipino word games created to celebrate the Filipino language.",
     type: "website",
-    url: "https://saltong.com/about",
+    url: canonicalUrl("/about"),
   },
 };
 

--- a/src/app/auth/page.test.ts
+++ b/src/app/auth/page.test.ts
@@ -4,7 +4,7 @@ import { metadata } from "./page";
 describe("authentication metadata", () => {
   it("keeps the login route out of the index while preserving its canonical", () => {
     expect(metadata).toMatchObject({
-      alternates: { canonical: "https://www.saltong.com/auth" },
+      alternates: { canonical: "https://saltong.com/auth" },
       robots: { index: false, follow: true },
     });
   });

--- a/src/app/auth/page.test.ts
+++ b/src/app/auth/page.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+import { metadata } from "./page";
+
+describe("authentication metadata", () => {
+  it("keeps the login route out of the index while preserving its canonical", () => {
+    expect(metadata).toMatchObject({
+      alternates: { canonical: "https://www.saltong.com/auth" },
+      robots: { index: false, follow: true },
+    });
+  });
+});

--- a/src/app/auth/page.tsx
+++ b/src/app/auth/page.tsx
@@ -3,9 +3,11 @@ import AuthForm from "./auth-form";
 import { createClient } from "@/lib/supabase/server";
 import { redirect, RedirectType } from "next/navigation";
 import { validateRedirect } from "@/lib/auth/validate-redirect";
+import { pageIndexingMetadata } from "@/lib/seo";
 
 export const metadata: Metadata = {
   title: "Saltong Hub | Log in",
+  ...pageIndexingMetadata("/auth", false),
 };
 
 export default async function LoginPage({

--- a/src/app/contribute/layout.tsx
+++ b/src/app/contribute/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import React from "react";
+import { canonicalUrl } from "@/lib/seo";
 
 export const metadata: Metadata = {
   title: "Support Saltong Hub - Contribute & Donate",
@@ -10,7 +11,7 @@ export const metadata: Metadata = {
     description:
       "Support the development of Saltong Hub. Help us keep Filipino word games free and accessible.",
     type: "website",
-    url: "https://saltong.com/contribute",
+    url: canonicalUrl("/contribute"),
   },
 };
 

--- a/src/app/filipino-wordle/page.test.ts
+++ b/src/app/filipino-wordle/page.test.ts
@@ -9,11 +9,11 @@ describe("Filipino word-game landing page", () => {
       description:
         "Play Saltong, a daily Filipino word game built around Filipino language and words.",
       alternates: {
-        canonical: "https://www.saltong.com/filipino-wordle",
+        canonical: "https://saltong.com/filipino-wordle",
       },
       robots: { index: true, follow: true },
       openGraph: {
-        url: "https://www.saltong.com/filipino-wordle",
+        url: "https://saltong.com/filipino-wordle",
       },
     });
     expect(String(metadata.description)).not.toMatch(/wordle|spelling bee/i);

--- a/src/app/groups/[groupId]/page.tsx
+++ b/src/app/groups/[groupId]/page.tsx
@@ -10,6 +10,7 @@ import { getUserGroupRole } from "@/features/groups/queries/get-user-group-role"
 import { createClient } from "@/lib/supabase/server";
 import { notFound } from "next/navigation";
 import { Metadata } from "next";
+import { canonicalUrl } from "@/lib/seo";
 
 interface GroupPageProps {
   params: Promise<{
@@ -37,7 +38,7 @@ export async function generateMetadata({
       title: `${group.name} | Saltong Hub`,
       description: `Join ${group.name} on Saltong Hub and compete with friends on group leaderboards.`,
       type: "website",
-      url: `https://saltong.com/groups/${groupId}`,
+      url: canonicalUrl(`/groups/${groupId}`),
     },
   };
 }

--- a/src/app/groups/create/page.tsx
+++ b/src/app/groups/create/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import HomeNavbarBrand from "@/app/components/home-navbar-brand";
 import { Navbar } from "@/components/shared/navbar";
 import CreateGroupForm from "@/features/groups/components/create-group-form";
+import { canonicalUrl } from "@/lib/seo";
 
 export const metadata: Metadata = {
   title: "Create Group | Saltong Hub",
@@ -12,7 +13,7 @@ export const metadata: Metadata = {
     description:
       "Create your own group and compete with friends on leaderboards.",
     type: "website",
-    url: "https://saltong.com/groups/create",
+    url: canonicalUrl("/groups/create"),
   },
 };
 

--- a/src/app/groups/page.tsx
+++ b/src/app/groups/page.tsx
@@ -6,6 +6,7 @@ import { getUserGroups } from "@/features/groups/queries/get-group";
 import GroupListScreen from "@/features/groups/components/group-list-screen";
 import { Navbar } from "@/components/shared/navbar";
 import HomeNavbarBrand from "../components/home-navbar-brand";
+import { canonicalUrl } from "@/lib/seo";
 
 export const metadata: Metadata = {
   title: "Saltong Hub | Groups",
@@ -16,7 +17,7 @@ export const metadata: Metadata = {
     description:
       "Create and join groups. Play Saltong with friends and compete on group leaderboards.",
     type: "website",
-    url: "https://saltong.com/groups",
+    url: canonicalUrl("/groups"),
   },
 };
 

--- a/src/app/j/[inviteCode]/page.tsx
+++ b/src/app/j/[inviteCode]/page.tsx
@@ -19,6 +19,7 @@ import { getProfileFormData } from "@/features/profiles/utils";
 import { createClient } from "@/lib/supabase/server";
 import JoinGroupButton from "./join-group-button";
 import { Metadata } from "next";
+import { canonicalUrl } from "@/lib/seo";
 
 interface JoinGroupPageProps {
   params: Promise<{
@@ -45,7 +46,7 @@ export async function generateMetadata({
       title: `Join ${group.name} | Saltong Hub`,
       description: `Join ${group.name} on Saltong Hub.`,
       type: "website",
-      url: `https://saltong.com/j/${inviteCode}`,
+      url: canonicalUrl(`/j/${inviteCode}`),
     },
   };
 }

--- a/src/app/page.test.tsx
+++ b/src/app/page.test.tsx
@@ -1,0 +1,38 @@
+import { createElement, type ReactNode } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("./components/daily-games-card", () => ({
+  default: () => createElement("div"),
+}));
+vi.mock("./components/hex-games-card", () => ({
+  default: () => createElement("div"),
+}));
+vi.mock("./components/game-card", () => ({
+  default: () => createElement("div"),
+}));
+vi.mock("./components/home-navbar-brand", () => ({
+  default: () => createElement("div"),
+}));
+vi.mock("@/components/banners/create-account-banner", () => ({
+  default: () => createElement("div"),
+}));
+vi.mock("@/components/banners/numbers-games-banner", () => ({
+  default: () => createElement("div"),
+}));
+vi.mock("@/components/shared/navbar", () => ({
+  Navbar: ({ children }: { children: ReactNode }) =>
+    createElement("div", null, children),
+}));
+
+import HomePage from "./page";
+
+describe("home page SEO discovery", () => {
+  it("links visitors and crawlers to the Filipino word-game landing page", async () => {
+    const page = await HomePage();
+    const markup = renderToStaticMarkup(page);
+
+    expect(markup).toContain('href="/filipino-wordle"');
+    expect(markup).toContain("Looking for a Filipino word game?");
+  });
+});

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 import { Navbar } from "@/components/shared/navbar";
 import DailyGamesCard from "./components/daily-games-card";
 import HexGamesCard from "./components/hex-games-card";
@@ -54,6 +55,17 @@ export default async function HomePage() {
         <div className="mx-auto mt-6 max-w-6xl px-4">
           <NumbersGamesBanner />
         </div>
+        <section
+          className="mx-auto mt-6 max-w-6xl px-4"
+          aria-label="Filipino word game"
+        >
+          <p className="text-muted-foreground text-sm">
+            Looking for a Filipino word game?{" "}
+            <Link href="/filipino-wordle" className="text-primary underline">
+              Learn more about Saltong.
+            </Link>
+          </p>
+        </section>
         <div className="@container/bot mx-auto w-full max-w-5xl space-y-8 px-4 py-8">
           <h3>All Games</h3>
           <div className="grid grid-cols-1 gap-4 @min-[600px]/bot:grid-cols-2">

--- a/src/app/patch-notes/posts/introducing-saltong-hub.mdx
+++ b/src/app/patch-notes/posts/introducing-saltong-hub.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Introducing Saltong Hub: The New Home for Filipino Word Games"
 publishedAt: "2025-11-15"
-summary: "Starting January 1, 2026, Saltong is moving to its new, permanent home at www.saltong.com! Check out the exciting new features like saved progress, playing on any device, and access to all past puzzles"
+summary: "Starting January 1, 2026, Saltong is moving to its new, permanent home at saltong.com! Check out the exciting new features like saved progress, playing on any device, and access to all past puzzles"
 author: "Carl de Guia"
 tags: ["announcement"]
 heroImage: "/patch-notes/saltong-hub-cover.jpg"
@@ -9,7 +9,7 @@ heroImage: "/patch-notes/saltong-hub-cover.jpg"
 
 After years of sharing your daily word puzzle fix, Saltong is getting a huge, exciting upgrade! 
 
-Starting January 1, 2026, the original Saltong site at saltong.carldegs.com will close its doors, and all the fun will move to our new, permanent address: **[Saltong Hub at www.saltong.com](https://www.saltong.com)**!
+Starting January 1, 2026, the original Saltong site at saltong.carldegs.com will close its doors, and all the fun will move to our new, permanent address: **[Saltong Hub at saltong.com](https://saltong.com)**!
 
 But you don't have to wait! Saltong Hub is ready to play NOW in Open Beta. Start exploring the new features today, and help us find and fix any small issues before the official launch on January 1.
 
@@ -57,7 +57,7 @@ Let's look ahead! Think of this as the perfect chance for a Fresh Start. New yea
 
 ## What Happens to the Old Site?
 
-The original site will stop hosting new puzzles and will automatically send you to the new home at [www.saltong.com](https://www.saltong.com).
+The original site will stop hosting new puzzles and will automatically send you to the new home at [saltong.com](https://saltong.com).
 
 ## Found a Bug? Need Help?
 
@@ -71,8 +71,8 @@ Whether you have a question about the move, found a bug, or just want to suggest
 
 ### What You Can Do Now:
 
-1. **Visit [www.saltong.com](https://www.saltong.com)** and explore the new site
+1. **Visit [saltong.com](https://saltong.com)** and explore the new site
 2. **Report bugs** - Found something broken? Let me know at [carl@carldegs.com](mailto:carl@carldegs.com) so I can fix it before the official launch
 3. **Share with friends** - Spread the word about our new home
-4. **Bookmark www.saltong.com** - Make it easy to visit daily
-5. **[Contribute and donate](https://www.saltong.com/contribute)** - Keeping Saltong Hub running and adding new features isn't free. Your support helps me keep it ad-free and available for everyone!
+4. **Bookmark saltong.com** - Make it easy to visit daily
+5. **[Contribute and donate](https://saltong.com/contribute)** - Keeping Saltong Hub running and adding new features isn't free. Your support helps me keep it ad-free and available for everyone!

--- a/src/app/patch-notes/posts/introducing-saltong-hub.mdx
+++ b/src/app/patch-notes/posts/introducing-saltong-hub.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Introducing Saltong Hub: The New Home for Filipino Word Games"
 publishedAt: "2025-11-15"
-summary: "Starting January 1, 2026, Saltong is moving to its new, permanent home at saltong.com! Check out the exciting new features like saved progress, playing on any device, and access to all past puzzles"
+summary: "Starting January 1, 2026, Saltong is moving to its new, permanent home at www.saltong.com! Check out the exciting new features like saved progress, playing on any device, and access to all past puzzles"
 author: "Carl de Guia"
 tags: ["announcement"]
 heroImage: "/patch-notes/saltong-hub-cover.jpg"
@@ -9,7 +9,7 @@ heroImage: "/patch-notes/saltong-hub-cover.jpg"
 
 After years of sharing your daily word puzzle fix, Saltong is getting a huge, exciting upgrade! 
 
-Starting January 1, 2026, the original Saltong site at saltong.carldegs.com will close its doors, and all the fun will move to our new, permanent address: **[Saltong Hub at saltong.com](https://saltong.com)**! 
+Starting January 1, 2026, the original Saltong site at saltong.carldegs.com will close its doors, and all the fun will move to our new, permanent address: **[Saltong Hub at www.saltong.com](https://www.saltong.com)**!
 
 But you don't have to wait! Saltong Hub is ready to play NOW in Open Beta. Start exploring the new features today, and help us find and fix any small issues before the official launch on January 1.
 
@@ -57,7 +57,7 @@ Let's look ahead! Think of this as the perfect chance for a Fresh Start. New yea
 
 ## What Happens to the Old Site?
 
-The original site will stop hosting new puzzles and will automatically send you to the new home at [saltong.com](https://saltong.com).
+The original site will stop hosting new puzzles and will automatically send you to the new home at [www.saltong.com](https://www.saltong.com).
 
 ## Found a Bug? Need Help?
 
@@ -71,8 +71,8 @@ Whether you have a question about the move, found a bug, or just want to suggest
 
 ### What You Can Do Now:
 
-1. **Visit [saltong.com](https://saltong.com)** and explore the new site
+1. **Visit [www.saltong.com](https://www.saltong.com)** and explore the new site
 2. **Report bugs** - Found something broken? Let me know at [carl@carldegs.com](mailto:carl@carldegs.com) so I can fix it before the official launch
 3. **Share with friends** - Spread the word about our new home
-4. **Bookmark saltong.com** - Make it easy to visit daily
-5. **[Contribute and donate](https://saltong.com/contribute)** - Keeping Saltong Hub running and adding new features isn't free. Your support helps me keep it ad-free and available for everyone!
+4. **Bookmark www.saltong.com** - Make it easy to visit daily
+5. **[Contribute and donate](https://www.saltong.com/contribute)** - Keeping Saltong Hub running and adding new features isn't free. Your support helps me keep it ad-free and available for everyone!

--- a/src/app/patch-notes/posts/leaderboards-valentines-update.mdx
+++ b/src/app/patch-notes/posts/leaderboards-valentines-update.mdx
@@ -20,7 +20,7 @@ All games now support leaderboards:
 
 Whether you’re racing to solve in 2 turns or grinding for a higher Hex score, every game now comes with bragging rights.
 
-To create or join groups and leaderboards, a **Saltong account** is required, which you can create for free [here](https://saltong.com/auth?signup=1).
+To create or join groups and leaderboards, a **Saltong account** is required, which you can create for free [here](https://www.saltong.com/auth?signup=1).
 
 ### Creating a Group
 
@@ -28,7 +28,7 @@ Making a group is quick and easy:
 
 - Click **Create Group** from the sidebar  
 - Or use the **Create Group** button on the Groups page  
-- Or go directly to: [https://saltong.com/groups/create](https://saltong.com/groups/create)
+- Or go directly to: [https://www.saltong.com/groups/create](https://www.saltong.com/groups/create)
 
 You only need a **group name** to get started.
 
@@ -95,6 +95,6 @@ If you have feedback or suggestions, feel free to reach out at
 📧 **carl@carldegs.com**
 
 If you’d like to help keep Saltong **free and ad-free**, you can also contribute here:  
-👉 *[https://saltong.com/contribute](https://saltong.com/contribute)*
+👉 *[https://www.saltong.com/contribute](https://www.saltong.com/contribute)*
 
 Good luck, and may your guesses be ever in your favor.

--- a/src/app/patch-notes/posts/leaderboards-valentines-update.mdx
+++ b/src/app/patch-notes/posts/leaderboards-valentines-update.mdx
@@ -20,7 +20,7 @@ All games now support leaderboards:
 
 Whether you’re racing to solve in 2 turns or grinding for a higher Hex score, every game now comes with bragging rights.
 
-To create or join groups and leaderboards, a **Saltong account** is required, which you can create for free [here](https://www.saltong.com/auth?signup=1).
+To create or join groups and leaderboards, a **Saltong account** is required, which you can create for free [here](https://saltong.com/auth?signup=1).
 
 ### Creating a Group
 
@@ -28,7 +28,7 @@ Making a group is quick and easy:
 
 - Click **Create Group** from the sidebar  
 - Or use the **Create Group** button on the Groups page  
-- Or go directly to: [https://www.saltong.com/groups/create](https://www.saltong.com/groups/create)
+- Or go directly to: [https://saltong.com/groups/create](https://saltong.com/groups/create)
 
 You only need a **group name** to get started.
 
@@ -95,6 +95,6 @@ If you have feedback or suggestions, feel free to reach out at
 📧 **carl@carldegs.com**
 
 If you’d like to help keep Saltong **free and ad-free**, you can also contribute here:  
-👉 *[https://www.saltong.com/contribute](https://www.saltong.com/contribute)*
+👉 *[https://saltong.com/contribute](https://saltong.com/contribute)*
 
 Good luck, and may your guesses be ever in your favor.

--- a/src/app/play/hex/page.test.ts
+++ b/src/app/play/hex/page.test.ts
@@ -14,9 +14,9 @@ describe("Saltong Hex metadata", () => {
 
     expect(metadata).toMatchObject({
       title: "Saltong Hex #27",
-      alternates: { canonical: "https://www.saltong.com/play/hex" },
+      alternates: { canonical: "https://saltong.com/play/hex" },
       robots: { index: false, follow: true },
-      openGraph: { url: "https://www.saltong.com/play/hex" },
+      openGraph: { url: "https://saltong.com/play/hex" },
     });
   });
 });

--- a/src/app/play/mathinik/page.test.ts
+++ b/src/app/play/mathinik/page.test.ts
@@ -9,9 +9,9 @@ describe("Mathinik metadata", () => {
     });
 
     expect(metadata).toMatchObject({
-      alternates: { canonical: "https://www.saltong.com/play/mathinik" },
+      alternates: { canonical: "https://saltong.com/play/mathinik" },
       robots: { index: false, follow: true },
-      openGraph: { url: "https://www.saltong.com/play/mathinik" },
+      openGraph: { url: "https://saltong.com/play/mathinik" },
     });
   });
 });

--- a/src/app/play/mathinik/vault/page.test.ts
+++ b/src/app/play/mathinik/vault/page.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { metadata } from "./page";
+
+describe("Mathinik Vault metadata", () => {
+  it("uses a stable noindex canonical", () => {
+    expect(metadata).toMatchObject({
+      alternates: {
+        canonical: "https://www.saltong.com/play/mathinik/vault",
+      },
+      robots: { index: false, follow: true },
+      openGraph: { url: "https://www.saltong.com/play/mathinik/vault" },
+    });
+  });
+});

--- a/src/app/play/mathinik/vault/page.test.ts
+++ b/src/app/play/mathinik/vault/page.test.ts
@@ -5,10 +5,10 @@ describe("Mathinik Vault metadata", () => {
   it("uses a stable noindex canonical", () => {
     expect(metadata).toMatchObject({
       alternates: {
-        canonical: "https://www.saltong.com/play/mathinik/vault",
+        canonical: "https://saltong.com/play/mathinik/vault",
       },
       robots: { index: false, follow: true },
-      openGraph: { url: "https://www.saltong.com/play/mathinik/vault" },
+      openGraph: { url: "https://saltong.com/play/mathinik/vault" },
     });
   });
 });

--- a/src/app/play/mathinik/vault/page.tsx
+++ b/src/app/play/mathinik/vault/page.tsx
@@ -1,14 +1,18 @@
 import type { Metadata } from "next";
 import MathinikVaultPage from "@/features/mathinik/templates/mathinik-vault-page";
+import { canonicalUrl, pageIndexingMetadata } from "@/lib/seo";
+
+const path = "/play/mathinik/vault";
 
 export const metadata: Metadata = {
+  ...pageIndexingMetadata(path, false),
   title: "Mathinik Vault",
   description: "Browse archived Mathinik rounds and open previous dates.",
   openGraph: {
     title: "Mathinik Vault",
     description: "Browse archived Mathinik rounds and open previous dates.",
     type: "website",
-    url: "https://saltong.com/play/mathinik/vault",
+    url: canonicalUrl(path),
   },
 };
 

--- a/src/app/play/sudoku/[difficulty]/page.test.ts
+++ b/src/app/play/sudoku/[difficulty]/page.test.ts
@@ -11,10 +11,10 @@ describe("Sudoku difficulty metadata", () => {
 
     expect(metadata).toMatchObject({
       alternates: {
-        canonical: "https://www.saltong.com/play/sudoku/easy",
+        canonical: "https://saltong.com/play/sudoku/easy",
       },
       robots: { index: false, follow: true },
-      openGraph: { url: "https://www.saltong.com/play/sudoku/easy" },
+      openGraph: { url: "https://saltong.com/play/sudoku/easy" },
     });
   });
 });

--- a/src/app/play/sudoku/page.tsx
+++ b/src/app/play/sudoku/page.tsx
@@ -1,5 +1,6 @@
 import { Metadata } from "next";
 import SudokuSelectorPage from "@/features/sudoku/templates/sudoku-selector-page";
+import { canonicalUrl } from "@/lib/seo";
 
 export const metadata: Metadata = {
   title: "Sudoku",
@@ -8,7 +9,7 @@ export const metadata: Metadata = {
     title: "Sudoku",
     description: "Choose a Sudoku difficulty and play today’s grid.",
     type: "website",
-    url: "https://saltong.com/play/sudoku",
+    url: canonicalUrl("/play/sudoku"),
   },
 };
 

--- a/src/app/play/sudoku/vault/page.test.ts
+++ b/src/app/play/sudoku/vault/page.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { metadata } from "./page";
+
+describe("Sudoku Vault metadata", () => {
+  it("uses a stable noindex canonical", () => {
+    expect(metadata).toMatchObject({
+      alternates: {
+        canonical: "https://www.saltong.com/play/sudoku/vault",
+      },
+      robots: { index: false, follow: true },
+      openGraph: { url: "https://www.saltong.com/play/sudoku/vault" },
+    });
+  });
+});

--- a/src/app/play/sudoku/vault/page.test.ts
+++ b/src/app/play/sudoku/vault/page.test.ts
@@ -5,10 +5,10 @@ describe("Sudoku Vault metadata", () => {
   it("uses a stable noindex canonical", () => {
     expect(metadata).toMatchObject({
       alternates: {
-        canonical: "https://www.saltong.com/play/sudoku/vault",
+        canonical: "https://saltong.com/play/sudoku/vault",
       },
       robots: { index: false, follow: true },
-      openGraph: { url: "https://www.saltong.com/play/sudoku/vault" },
+      openGraph: { url: "https://saltong.com/play/sudoku/vault" },
     });
   });
 });

--- a/src/app/play/sudoku/vault/page.tsx
+++ b/src/app/play/sudoku/vault/page.tsx
@@ -1,14 +1,18 @@
 import { Metadata } from "next";
 import SudokuVaultPage from "@/features/sudoku/templates/sudoku-vault-page";
+import { canonicalUrl, pageIndexingMetadata } from "@/lib/seo";
+
+const path = "/play/sudoku/vault";
 
 export const metadata: Metadata = {
+  ...pageIndexingMetadata(path, false),
   title: "Sudoku Vault",
   description: "Browse archived Sudoku routes and open previous dates.",
   openGraph: {
     title: "Sudoku Vault",
     description: "Browse archived Sudoku routes and open previous dates.",
     type: "website",
-    url: "https://saltong.com/play/sudoku/vault",
+    url: canonicalUrl(path),
   },
 };
 

--- a/src/app/policies/cookies/page.mdx
+++ b/src/app/policies/cookies/page.mdx
@@ -2,7 +2,7 @@
 
 **Last updated: January 10, 2026**
 
-This Cookie Policy explains how Saltong ("Saltong," "we," "us," or "our") uses cookies and similar technologies to recognize you when you visit [https://saltong.com](https://saltong.com) and related pages (collectively, the "Website"). It describes the types of cookies we serve, why we use them, and the controls available to you.
+This Cookie Policy explains how Saltong ("Saltong," "we," "us," or "our") uses cookies and similar technologies to recognize you when you visit [https://www.saltong.com](https://www.saltong.com) and related pages (collectively, the "Website"). It describes the types of cookies we serve, why we use them, and the controls available to you.
 
 We may combine cookie-derived information with other data about you and treat the aggregated information as personal data. Where required by law, we will request your consent before setting non-essential cookies.
 

--- a/src/app/policies/cookies/page.mdx
+++ b/src/app/policies/cookies/page.mdx
@@ -2,7 +2,7 @@
 
 **Last updated: January 10, 2026**
 
-This Cookie Policy explains how Saltong ("Saltong," "we," "us," or "our") uses cookies and similar technologies to recognize you when you visit [https://www.saltong.com](https://www.saltong.com) and related pages (collectively, the "Website"). It describes the types of cookies we serve, why we use them, and the controls available to you.
+This Cookie Policy explains how Saltong ("Saltong," "we," "us," or "our") uses cookies and similar technologies to recognize you when you visit [https://saltong.com](https://saltong.com) and related pages (collectively, the "Website"). It describes the types of cookies we serve, why we use them, and the controls available to you.
 
 We may combine cookie-derived information with other data about you and treat the aggregated information as personal data. Where required by law, we will request your consent before setting non-essential cookies.
 

--- a/src/app/policies/page.tsx
+++ b/src/app/policies/page.tsx
@@ -14,6 +14,7 @@ import {
   SettingsSectionList,
   SettingsSectionItemLink,
 } from "../settings/components/settings-section";
+import { canonicalUrl } from "@/lib/seo";
 
 export const metadata: Metadata = {
   title: "Policies | Saltong Hub",
@@ -23,7 +24,7 @@ export const metadata: Metadata = {
     title: "Policies - Saltong Hub",
     description: "Review our policies and terms for using Saltong Hub.",
     type: "website",
-    url: "https://saltong.com/policies",
+    url: canonicalUrl("/policies"),
   },
 };
 

--- a/src/app/policies/privacy/page.mdx
+++ b/src/app/policies/privacy/page.mdx
@@ -2,7 +2,7 @@
 
 **Last updated: November 15, 2025**
 
-This Privacy Policy explains how Saltong ("Saltong," "we," "us," or "our") collects, uses, discloses, and safeguards information about you when you use our website and services (the "Services"), including at [https://saltong.com](https://saltong.com) and any page that links to this Policy.
+This Privacy Policy explains how Saltong ("Saltong," "we," "us," or "our") collects, uses, discloses, and safeguards information about you when you use our website and services (the "Services"), including at [https://www.saltong.com](https://www.saltong.com) and any page that links to this Policy.
 
 **By using the Services, you agree to the practices described here. If you do not agree, please do not use the Services.** You can contact us any time at [carl@carldegs.com](mailto:carl@carldegs.com).
 

--- a/src/app/policies/privacy/page.mdx
+++ b/src/app/policies/privacy/page.mdx
@@ -2,7 +2,7 @@
 
 **Last updated: November 15, 2025**
 
-This Privacy Policy explains how Saltong ("Saltong," "we," "us," or "our") collects, uses, discloses, and safeguards information about you when you use our website and services (the "Services"), including at [https://www.saltong.com](https://www.saltong.com) and any page that links to this Policy.
+This Privacy Policy explains how Saltong ("Saltong," "we," "us," or "our") collects, uses, discloses, and safeguards information about you when you use our website and services (the "Services"), including at [https://saltong.com](https://saltong.com) and any page that links to this Policy.
 
 **By using the Services, you agree to the practices described here. If you do not agree, please do not use the Services.** You can contact us any time at [carl@carldegs.com](mailto:carl@carldegs.com).
 

--- a/src/app/sitemap.test.ts
+++ b/src/app/sitemap.test.ts
@@ -13,6 +13,7 @@ describe("sitemap", () => {
     expect(sitemap()).toContainEqual(
       expect.objectContaining({
         url: "https://www.saltong.com/filipino-wordle",
+        lastModified: new Date("2026-08-21T00:00:00.000Z"),
         changeFrequency: "monthly",
         priority: 0.8,
       })

--- a/src/app/sitemap.test.ts
+++ b/src/app/sitemap.test.ts
@@ -12,7 +12,7 @@ describe("sitemap", () => {
   it("submits the evergreen Filipino word-game landing page", () => {
     expect(sitemap()).toContainEqual(
       expect.objectContaining({
-        url: "https://www.saltong.com/filipino-wordle",
+        url: "https://saltong.com/filipino-wordle",
         lastModified: new Date("2026-08-21T00:00:00.000Z"),
         changeFrequency: "monthly",
         priority: 0.8,
@@ -24,12 +24,12 @@ describe("sitemap", () => {
     expect(sitemap()).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          url: "https://www.saltong.com/play/sudoku",
+          url: "https://saltong.com/play/sudoku",
           changeFrequency: "daily",
           priority: 1,
         }),
         expect.objectContaining({
-          url: "https://www.saltong.com/play/mathinik",
+          url: "https://saltong.com/play/mathinik",
           changeFrequency: "daily",
           priority: 1,
         }),

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -3,6 +3,7 @@ import { getBlogPosts } from "./patch-notes/utils";
 import { SITE_URL } from "@/lib/seo";
 
 const baseUrl = SITE_URL;
+const FILIPINO_WORDLE_LAST_MODIFIED = new Date("2026-08-21T00:00:00.000Z");
 
 // Play game variants
 const playVariants = ["", "mini", "max", "hex", "sudoku", "mathinik"];
@@ -45,7 +46,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
     },
     {
       url: `${baseUrl}/filipino-wordle`,
-      lastModified: new Date(),
+      lastModified: FILIPINO_WORDLE_LAST_MODIFIED,
       changeFrequency: "monthly" as const,
       priority: 0.8,
     },

--- a/src/app/u/[userId]/page.tsx
+++ b/src/app/u/[userId]/page.tsx
@@ -22,6 +22,7 @@ import { NumberTicker } from "@/components/ui/number-ticker";
 import Link from "next/link";
 import { getProfileById } from "@/features/profiles/queries/get-profile";
 import { Metadata } from "next";
+import { canonicalUrl } from "@/lib/seo";
 
 // For now, only the user can view their own profile. Need to setup a public table for profiles later.
 
@@ -52,7 +53,7 @@ export async function generateMetadata(): Promise<Metadata> {
       title: `${profile.display_name} - Saltong Hub Profile`,
       description: `Check out ${profile.display_name}'s Saltong Hub profile and stats.`,
       type: "profile",
-      url: `https://saltong.com/u/${userId}`,
+      url: canonicalUrl(`/u/${userId}`),
     },
   };
 }

--- a/src/features/saltong/utils/generateSaltongMetadata.test.ts
+++ b/src/features/saltong/utils/generateSaltongMetadata.test.ts
@@ -20,9 +20,9 @@ describe("generateSaltongMetadata", () => {
 
       expect(metadata).toMatchObject({
         title,
-        alternates: { canonical: `https://www.saltong.com${path}` },
+        alternates: { canonical: `https://saltong.com${path}` },
         robots: { index: false, follow: true },
-        openGraph: { url: `https://www.saltong.com${path}` },
+        openGraph: { url: `https://saltong.com${path}` },
       });
     }
   );

--- a/src/lib/seo-hosts.test.ts
+++ b/src/lib/seo-hosts.test.ts
@@ -1,0 +1,29 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const PUBLIC_SOURCE_FILES = [
+  "src/app/about/page.tsx",
+  "src/app/contribute/layout.tsx",
+  "src/app/groups/page.tsx",
+  "src/app/groups/create/page.tsx",
+  "src/app/groups/[groupId]/page.tsx",
+  "src/app/j/[inviteCode]/page.tsx",
+  "src/app/u/[userId]/page.tsx",
+  "src/app/policies/page.tsx",
+  "src/app/play/sudoku/page.tsx",
+  "src/app/play/sudoku/vault/page.tsx",
+  "src/app/play/mathinik/vault/page.tsx",
+  "src/app/patch-notes/posts/introducing-saltong-hub.mdx",
+  "src/app/patch-notes/posts/leaderboards-valentines-update.mdx",
+  "src/app/policies/cookies/page.mdx",
+  "src/app/policies/privacy/page.mdx",
+] as const;
+
+describe("public SEO host references", () => {
+  it.each(PUBLIC_SOURCE_FILES)("does not use the apex host in %s", (file) => {
+    const source = readFileSync(resolve(process.cwd(), file), "utf8");
+
+    expect(source).not.toContain("https://saltong.com");
+  });
+});

--- a/src/lib/seo-hosts.test.ts
+++ b/src/lib/seo-hosts.test.ts
@@ -3,6 +3,7 @@ import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 
 const PUBLIC_SOURCE_FILES = [
+  "src/lib/seo.ts",
   "src/app/about/page.tsx",
   "src/app/contribute/layout.tsx",
   "src/app/groups/page.tsx",
@@ -21,9 +22,9 @@ const PUBLIC_SOURCE_FILES = [
 ] as const;
 
 describe("public SEO host references", () => {
-  it.each(PUBLIC_SOURCE_FILES)("does not use the apex host in %s", (file) => {
+  it.each(PUBLIC_SOURCE_FILES)("does not use the www host in %s", (file) => {
     const source = readFileSync(resolve(process.cwd(), file), "utf8");
 
-    expect(source).not.toContain("https://saltong.com");
+    expect(source).not.toContain("https://www.saltong.com");
   });
 });

--- a/src/lib/seo.test.ts
+++ b/src/lib/seo.test.ts
@@ -2,23 +2,21 @@ import { describe, expect, it } from "vitest";
 import { SITE_URL, canonicalUrl, pageIndexingMetadata } from "./seo";
 
 describe("SEO metadata", () => {
-  it("uses the www host for public canonical URLs", () => {
-    expect(SITE_URL).toBe("https://www.saltong.com");
-    expect(canonicalUrl("/play/mini")).toBe(
-      "https://www.saltong.com/play/mini"
-    );
+  it("uses the apex host for public canonical URLs", () => {
+    expect(SITE_URL).toBe("https://saltong.com");
+    expect(canonicalUrl("/play/mini")).toBe("https://saltong.com/play/mini");
   });
 
   it("keeps canonical pages indexable", () => {
     expect(pageIndexingMetadata("/play", true)).toEqual({
-      alternates: { canonical: "https://www.saltong.com/play" },
+      alternates: { canonical: "https://saltong.com/play" },
       robots: { index: true, follow: true },
     });
   });
 
   it("prevents historical or gated pages from being indexed", () => {
     expect(pageIndexingMetadata("/play/mini", false)).toEqual({
-      alternates: { canonical: "https://www.saltong.com/play/mini" },
+      alternates: { canonical: "https://saltong.com/play/mini" },
       robots: { index: false, follow: true },
     });
   });
@@ -26,7 +24,7 @@ describe("SEO metadata", () => {
   it("marks a vault route noindex while retaining its canonical destination", () => {
     expect(pageIndexingMetadata("/play/mini/vault", false)).toEqual({
       alternates: {
-        canonical: "https://www.saltong.com/play/mini/vault",
+        canonical: "https://saltong.com/play/mini/vault",
       },
       robots: { index: false, follow: true },
     });

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 
-export const SITE_URL = "https://www.saltong.com";
+export const SITE_URL = "https://saltong.com";
 
 export function canonicalUrl(path: string) {
   return new URL(path, SITE_URL).toString();

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,5 +6,5 @@ const rootDir = dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
   resolve: { alias: { "@": resolve(rootDir, "src") } },
-  test: { environment: "node", include: ["src/**/*.test.ts"] },
+  test: { environment: "node", include: ["src/**/*.test.{ts,tsx}"] },
 });


### PR DESCRIPTION
## Summary
- make https://saltong.com the sole canonical origin for metadata, sitemap entries, and first-party public links
- keep authentication and Sudoku/Mathinik vault routes noindex while preserving their apex canonicals
- retain the crawlable home-page link and stable sitemap timestamp for /filipino-wordle

## Validation
- pnpm test (50 passing)
- pnpm lint
- independent review: no findings

## Deployment prerequisite
The live www-to-apex host redirect is configured outside this repository. The Vercel account available to this session does not have access to saltong.com, so the domain owner must set www.saltong.com to permanently redirect to https://saltong.com before or alongside deployment.

## Build note
The prior pnpm build attempt hung at `Creating an optimized production build ...` while Next/Turbopack held its build lock and emitted no application error. Confirm the build in CI or a network-enabled environment.